### PR TITLE
feat: 방문 기록 및 UI 개선 - 날짜/메모 동시 업데이트, 입력 형식 개선, 액션 열 변경

### DIFF
--- a/app/visit.py
+++ b/app/visit.py
@@ -55,13 +55,13 @@ def get_visit_by_visit_id(visit_id):
     return execute_query(query, (visit_id,), fetch_one=True)
 
 # 방문 기록 수정
-def update_visit(visit_id, memo):
+def update_visit(visit_id, visit_data):
     query = """
-    UPDATE visit SET memo = %s WHERE visit_id = %s
+    UPDATE visit SET visit_date = %s, memo = %s WHERE visit_id = %s
     """
 
     try:
-        execute_query(query, (memo, visit_id))
+        execute_query(query, (visit_data["visit_date"], visit_data["memo"], visit_id))
         print(f"방문 기록 수정 성공: 방문 ID {visit_id}")
 
         return True

--- a/routes/visit_routes.py
+++ b/routes/visit_routes.py
@@ -53,8 +53,12 @@ def visit_edit(visit_id):
         return redirect(url_for("visit.visit_list"))
 
     if request.method == "POST":
-        memo = request.form["memo"]
-        if update_visit(visit_id, memo):
+        visit_data = {
+            "visit_date": request.form["visit_date"],
+            "memo": request.form["memo"]
+        }
+        
+        if update_visit(visit_id, visit_data):
             flash("방문 기록 수정 성공", "success")
             return redirect(url_for("visit.visit_list"))
         else:

--- a/templates/customers/detail.html
+++ b/templates/customers/detail.html
@@ -110,7 +110,7 @@
                                 <tr>
                                     <th>방문일</th>
                                     <th>메모</th>
-                                    <th>액션</th>
+                                    <th>관리</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -161,7 +161,7 @@
                                     <th>방문일</th>
                                     <th>금액</th>
                                     <th>결제수단</th>
-                                    <th>액션</th>
+                                    <th>관리</th>
                                 </tr>
                             </thead>
                             <tbody>

--- a/templates/customers/list.html
+++ b/templates/customers/list.html
@@ -60,7 +60,7 @@
                             <th>생년월일</th>
                             <th>성별</th>
                             <th>메모</th>
-                            <th>액션</th>
+                            <th>관리</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -126,7 +126,18 @@
                                             {{ visit.customer_name }}
                                         </a>
                                     </td>
-                                    <td>{{ visit.visit_date }}</td>
+                                    <td>
+                                        {% if visit.visit_date %}
+                                            {{ visit.visit_date.strftime('%Y-%m-%d') }}
+                                            {% if visit.visit_date.hour < 12 %}
+                                                오전 {{ visit.visit_date.strftime('%I:%M').lstrip('0') }}
+                                            {% else %}
+                                                오후 {{ visit.visit_date.strftime('%I:%M').lstrip('0') }}
+                                            {% endif %}
+                                        {% else %}
+                                            -
+                                        {% endif %}
+                                    </td>
                                     <td>{{ visit.memo or '-' }}</td>
                                 </tr>
                                 {% endfor %}
@@ -141,12 +152,12 @@
     </div>
 </div>
 
-<!-- 빠른 액션 버튼 -->
+<!-- 빠른 메뉴 버튼 -->
 <div class="row mt-4">
     <div class="col-12">
         <div class="card">
             <div class="card-header">
-                <h5 class="card-title mb-0">빠른 액션</h5>
+                <h5 class="card-title mb-0">빠른 메뉴</h5>
             </div>
             <div class="card-body">
                 <div class="row">

--- a/templates/payments/list.html
+++ b/templates/payments/list.html
@@ -27,7 +27,7 @@
                             <th>결제일시</th>
                             <th>금액</th>
                             <th>결제수단</th>
-                            <th>액션</th>
+                            <th>관리</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/templates/stats/customers.html
+++ b/templates/stats/customers.html
@@ -29,7 +29,7 @@
                             <th>총 결제</th>
                             <th>평균 결제</th>
                             <th>최근 방문</th>
-                            <th>액션</th>
+                            <th>관리</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/templates/visits/edit.html
+++ b/templates/visits/edit.html
@@ -26,8 +26,9 @@
                     </div>
                     
                     <div class="mb-3">
-                        <label for="visit_date" class="form-label">방문일</label>
-                        <input type="date" class="form-control" value="{{ visit.visit_date }}" readonly>
+                        <label for="visit_date" class="form-label">방문일시</label>
+                        <input type="datetime-local" class="form-control" id="visit_date" name="visit_date" 
+                               value="{{ visit.visit_date.strftime('%Y-%m-%dT%H:%M') if visit.visit_date else '' }}" required>
                     </div>
                     
                     <div class="mb-3">

--- a/templates/visits/list.html
+++ b/templates/visits/list.html
@@ -52,7 +52,7 @@
                             <th>고객명</th>
                             <th>방문일</th>
                             <th>메모</th>
-                            <th>액션</th>
+                            <th>관리</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -64,7 +64,18 @@
                                     {{ visit.customer_name }}
                                 </a>
                             </td>
-                            <td>{{ visit.visit_date }}</td>
+                            <td>
+                                {% if visit.visit_date %}
+                                    {{ visit.visit_date.strftime('%Y-%m-%d') }}
+                                    {% if visit.visit_date.hour < 12 %}
+                                        오전 {{ visit.visit_date.strftime('%I:%M').lstrip('0') }}
+                                    {% else %}
+                                        오후 {{ visit.visit_date.strftime('%I:%M').lstrip('0') }}
+                                    {% endif %}
+                                {% else %}
+                                    -
+                                {% endif %}
+                            </td>
                             <td>
                                 {% if visit.memo %}
                                     <span class="text-truncate d-inline-block" style="max-width: 200px;" 

--- a/templates/visits/new.html
+++ b/templates/visits/new.html
@@ -34,9 +34,8 @@
                     </div>
                     
                     <div class="mb-3">
-                        <label for="visit_date" class="form-label">방문일 <span class="text-danger">*</span></label>
-                        <input type="date" class="form-control" id="visit_date" name="visit_date" 
-                               value="{{ today }}" required>
+                        <label for="visit_date" class="form-label">방문일시 <span class="text-danger">*</span></label>
+                        <input type="datetime-local" class="form-control" id="visit_date" name="visit_date" required>
                     </div>
                     
                     <div class="mb-3">
@@ -60,10 +59,23 @@
 
 {% block scripts %}
 <script>
-// 오늘 날짜를 기본값으로 설정
+// 현재 한국 시간을 기본값으로 설정
 document.addEventListener('DOMContentLoaded', function() {
-    const today = new Date().toISOString().split('T')[0];
-    document.getElementById('visit_date').value = today;
+    // 한국 시간대 (UTC+9) 적용
+    const now = new Date();
+    const koreaOffset = 9 * 60; // 한국은 UTC+9
+    const utc = now.getTime() + (now.getTimezoneOffset() * 60000);
+    const koreaTime = new Date(utc + (koreaOffset * 60000));
+    
+    // datetime-local 형식으로 변환 (YYYY-MM-DDTHH:MM)
+    const year = koreaTime.getFullYear();
+    const month = String(koreaTime.getMonth() + 1).padStart(2, '0');
+    const day = String(koreaTime.getDate()).padStart(2, '0');
+    const hours = String(koreaTime.getHours()).padStart(2, '0');
+    const minutes = String(koreaTime.getMinutes()).padStart(2, '0');
+    
+    const datetimeLocal = `${year}-${month}-${day}T${hours}:${minutes}`;
+    document.getElementById('visit_date').value = datetimeLocal;
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
### 작업 내용
- 방문 기록 수정 기능 개선
  - 방문일과 메모를 함께 업데이트 가능하도록 수정
  - 방문일 입력 형식을 `datetime-local`로 변경하고 한국 시간 기본값 설정
- 대시보드/방문 목록 UI 개선
  - 방문 날짜 포맷 변경
  - 액션 버튼 텍스트를 '관리'로 통일
  - 버튼 스타일 및 위치 조정
- 관련 템플릿 전반 수정
  - 고객 상세, 목록, 결제 목록, 통계 템플릿에 동일한 액션 열 변경 적용

### 변경 이유
- 사용자가 한 번에 방문일과 메모를 수정할 수 있도록 UX 개선
- 한국 시간대 맞춤 입력 기본값 제공으로 편의성 향상
- UI 일관성 확보 및 가독성 개선

### 테스트 방법
1. 방문 기록 수정 페이지 접속
2. 방문일과 메모를 동시에 수정 후 저장
3. 대시보드와 방문 목록에서 변경 사항 반영 확인
4. 액션 버튼이 모두 '관리'로 표시되는지 확인

### 변경 후 화면

#### 1. 최근 방문 기록 시간 출력
<img width="1576" height="736" alt="스크린샷 2025-08-12 170626" src="https://github.com/user-attachments/assets/0fc5b474-6e6e-47f1-80d4-b9ab4f0366d0" />

#### 2. 방문 기록 시간 등록
<img width="1272" height="1021" alt="스크린샷 2025-08-12 170750" src="https://github.com/user-attachments/assets/6e12fa19-7e0f-4dea-8494-9d65fc62c9ff" />

#### 3. 버튼 텍스트 액션 -> 관리 전체 수정
<img width="3151" height="980" alt="스크린샷 2025-08-12 171127" src="https://github.com/user-attachments/assets/ba10f19a-4ac3-4a55-93cf-93c571856670" />
